### PR TITLE
Persist size of terminal across toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ require"toggleterm".setup{
   open_mapping = [[<c-\>]],
   shade_filetypes = {},
   shade_terminals = true
+  persist_size = true
   direction = 'vertical' | 'horizontal'
 }
 ```
@@ -97,6 +98,18 @@ require'toggleterm'.setup{
 ```
 
 setting `"none"` will allow normal terminal buffers to be highlighted.
+
+### Set persistent size
+
+By default, this plugin will persist the size of the terminal split. You can disable
+this behaviour by setting `persist_size = false` in the setup object. Disabling this
+behaviour forces the opening terminal size to the `size` defined in the setup object.
+
+```lua
+require'toggleterm'.setup{
+  persist_size = false
+}
+```
 
 ### Statusline
 

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -17,6 +17,7 @@ local preferences = {
   size = 12,
   shade_filetypes = {},
   shade_terminals = true,
+  persist_size = true,
   direction = "horizontal"
 }
 
@@ -30,10 +31,17 @@ local persistent = {}
 ---   1. The size argument is a valid number > 0
 ---   2. There is persistent width/height information from prev open state
 ---   3. Default/base case perference size
+---
+--- If `preferences.persist_size = false` then option `2` in the
+--- list is skipped.
 --- @param size number
 local function get_size(size)
-  local persist_size = preferences.direction == "horizontal" and persistent['height'] or persistent['width']
-  return (size and size > 0) and size or persist_size and persist_size or preferences.size
+  if not preferences.persist_size then
+    return (size and size > 0) or preferences.size
+  end
+
+  local psize = preferences.direction == "horizontal" and persistent['height'] or persistent['width']
+  return (size and size > 0) and size or psize or preferences.size
 end
 
 local function create_term()
@@ -123,6 +131,7 @@ local function resize(size)
 
   vim.cmd(cmd .. " " .. size)
 end
+
 --- @param size number
 local function open_split(size)
   size = get_size(size)

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -36,12 +36,13 @@ local persistent = {}
 --- list is skipped.
 --- @param size number
 local function get_size(size)
+  local valid_size = size ~= nil and size > 0
   if not preferences.persist_size then
-    return (size and size > 0) or preferences.size
+    return valid_size and size or preferences.size
   end
 
   local psize = preferences.direction == "horizontal" and persistent['height'] or persistent['width']
-  return (size and size > 0) and size or psize or preferences.size
+  return valid_size and size or psize or preferences.size
 end
 
 local function create_term()

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -24,6 +24,17 @@ local preferences = {
 -- State
 -----------------------------------------------------------
 local terminals = {}
+local persistent = {}
+
+--- Get the size of the split. Order of priority is as follows:
+---   1. The size argument is a valid number > 0
+---   2. There is persistent width/height information from prev open state
+---   3. Default/base case perference size
+--- @param size number
+local function get_size(size)
+  local persist_size = preferences.direction == "horizontal" and persistent['height'] or persistent['width']
+  return (size and size > 0) and size or persist_size and persist_size or preferences.size
+end
 
 local function create_term()
   local no_of_terms = table.getn(terminals)
@@ -112,9 +123,10 @@ local function resize(size)
 
   vim.cmd(cmd .. " " .. size)
 end
-
 --- @param size number
 local function open_split(size)
+  size = get_size(size)
+
   local has_open, win_ids = find_open_windows()
   local commands =
     preferences.direction == "horizontal" and
@@ -290,7 +302,7 @@ function M.on_term_open()
     term.job_id = vim.b.terminal_job_id
     terminals[num] = term
 
-    resize(preferences.size)
+    resize(get_size())
     set_opts(num, term.bufnr, term.window)
   end
 end
@@ -308,7 +320,6 @@ end
 function M.open(num, size)
   vim.validate {num = {num, "number"}, size = {size, "number", true}}
 
-  size = (size and size > 0) and size or preferences.size
   local term = find_term(num)
 
   if vim.fn.bufexists(term.bufnr) == 0 then
@@ -370,6 +381,10 @@ end
 function M.close(num)
   local term = find_term(num)
   if find_window(term.window) then
+    -- Save the size of the split before it is hidden
+    persistent['width'] = vim.fn.winwidth(0)
+    persistent['height'] = vim.fn.winheight(0)
+
     vim.cmd("hide")
   else
     if num then


### PR DESCRIPTION
Thanks for making this plugin. I could not find a simple way to create a popup/scratch terminal so I was about to write my own. 

This pr is adding persistent size to the terminal split. I use the popout terminal for things like compile checking my code. I find the the errors are longer then the terminal so I make it bigger to read. When I toggle it again it would change back to the size in the preference. 

Now before the split is hidden the size is saved to be later used when creating new open split.

![persist](https://user-images.githubusercontent.com/2746374/99631819-3d373580-2a0a-11eb-928d-9f94abf11df0.gif)
