### PR TITLE
`stopinsert' after hiding terminal

### DIFF
--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -406,6 +406,7 @@ function M.close(num)
     M.save_window_size()
 
     vim.cmd("hide")
+    vim.cmd("stopinsert!")
   else
     if num then
       vim.cmd(


### PR DESCRIPTION
When closing terminal from outside, it will leave you in mode that
you were in terminal.

example:
- open terminal - be in insert mode inside termnal
- move back to file - mode doesnt matter
- close terminal - and it will switch to insert mode