### PR TITLE
Add ability to tweak degree of shading

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ require"toggleterm".setup{
   open_mapping = [[<c-\>]],
   shade_filetypes = {},
   shade_terminals = true,
+  shading_factor = '<number>' -- the degree by which to darken to terminal colour, default: 1 for dark backgrounds, 3 for light
   start_in_insert = true,
   persist_size = true,
   direction = 'vertical' | 'horizontal',

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -12,6 +12,8 @@ local M = {
 -- Constants
 -----------------------------------------------------------
 local term_ft = "toggleterm"
+-- -30 is a magic number based on manual testing of what looks good
+local SHADING_AMOUNT = -30
 
 local preferences = {
   size = 12,
@@ -19,7 +21,8 @@ local preferences = {
   shade_terminals = true,
   start_in_insert = true,
   persist_size = true,
-  direction = "horizontal"
+  direction = "horizontal",
+  shading_factor = nil
 }
 
 -----------------------------------------------------------
@@ -475,7 +478,17 @@ function M.setup(user_prefs)
     }
   }
   if preferences.shade_terminals then
-    colors.set_highlights(-30)
+    local is_bright = colors.is_bright_background()
+
+    -- if background is light then darken the terminal a lot more to increase contrast
+    local factor =
+      preferences.shading_factor and type(preferences.shading_factor) == "number" and
+      preferences.shading_factor or
+      (is_bright and 3 or 1)
+
+    local amount = factor * SHADING_AMOUNT
+    colors.set_highlights(amount)
+
     vim.list_extend(
       autocommands,
       {
@@ -487,7 +500,7 @@ function M.setup(user_prefs)
           -- is re-applied
           "ColorScheme",
           "*",
-          "lua require'toggleterm'.__set_highlights(-30)"
+          string.format("lua require'toggleterm'.__set_highlights(%d)", amount)
         },
         {
           "TermOpen",

--- a/lua/toggleterm/colors.lua
+++ b/lua/toggleterm/colors.lua
@@ -42,6 +42,33 @@ local function shade_color(color, percent)
   return "#" .. rr .. gg .. bb
 end
 
+--- Determine whether to use black or white text
+--- Ref:
+--- 1. https://stackoverflow.com/a/1855903/837964
+--- 2. https://stackoverflow.com/a/596243
+function M.color_is_bright(hex)
+  if not hex then
+    return false
+  end
+  local r, g, b = to_rgb(hex)
+  -- If any of the colors are missing return false
+  if not r or not g or not b then
+    return false
+  end
+  -- Counting the perceptive luminance - human eye favors green color
+  local luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255
+  if luminance > 0.5 then
+    return true -- Bright colors, black font
+  else
+    return false -- Dark colors, white font
+  end
+end
+
+function M.is_bright_background()
+  local bg_color = fn.synIDattr(fn.hlID("Normal"), "bg")
+  return M.color_is_bright(bg_color)
+end
+
 -----------------------------------------------------------
 -- Darken Terminal
 -----------------------------------------------------------


### PR DESCRIPTION
This PR adds `shading_factor` to the available options so a user can tweak the amount of shading for the terminal buffer. It also darkens light backgrounds more by default.

![image](https://user-images.githubusercontent.com/22454918/107982177-78221880-6fbb-11eb-9c77-89f1942383d7.png)