### PR TITLE
Add ability to specify opening directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ remain in that dir
 ### `TermExec`
 
 This command allows you to open a terminal with a specific action.
-e.g. `2TermExec git status` will run git status in terminal 2.
+e.g. `2TermExec cmd="git status" dir=~/<my-repo-path>` will run git status in terminal 2.
+note that the `cmd` argument is quoted so that can it can be distinguished from the `dir`
+argument.
 
 ### Set terminal shading
 
@@ -153,4 +155,14 @@ You can create your on commands by using the lua functions this plugin provides 
 ```vim
 command! -count=1 TermGitPush  lua require'toggleterm'.exec("git push",    <count>, 12)
 command! -count=1 TermGitPushF lua require'toggleterm'.exec("git push -f", <count>, 12)
+```
+
+or in lua:
+
+```lua
+function _G.term_git_push()
+  require('toggleterm').exec("git push", vim.v.count, 20)
+end
+
+vim.api.nvim_set_keymap("n", "<map>", [[<cmd>lua _G.term_git_push()]], {silent = true, noremap = true})
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ A _neovim_ plugin to persist and toggle multiple terminals during an editing ses
 
 ![exec](https://user-images.githubusercontent.com/22454918/112119367-36d1e980-8bb5-11eb-9787-5936391127a3.gif)
 
+## Notices
+
+- **23/03/2021**: `TermExec` command syntax has been refactored to use `TermExec cmd='my-command'`
+
 ## Why?
 
 Neovim's terminal is a very cool, but not super ergonomic tool to use. I find that I often want to

--- a/README.md
+++ b/README.md
@@ -40,11 +40,9 @@ I won't be turning this into a REPL plugin or doing a bunch of complex stuff.
 If you find any issues, _please_ consider a _pull request_ not an issue. I won't be breaking my back to maintain
 this especially if it isn't broken "on my machine". I'm also going to be pretty conservative about what I add.
 
-### Usage
+### Setup
 
-## NOTE:
-
-This plugin must now be explicitly enabled by using `require"toggleterm".setup{}`
+This plugin must be explicitly enabled by using `require"toggleterm".setup{}`
 
 Setting the key to use for toggling the terminal(s) will setup mappings for _insert, normal and terminal_ modes
 If you prefix the mapping with a number that particular terminal will be opened.
@@ -77,6 +75,31 @@ autocmd TermEnter term://*toggleterm#*
 nnoremap <silent><c-t> :<c-u>exe v:count1 . "ToggleTerm"<CR>
 inoremap <silent><c-t> <Esc>:<c-u>exe v:count1 . "ToggleTerm"<CR>
 ```
+
+### Usage
+
+This plugin provides 2 commands
+
+### `ToggleTerm`
+
+This is the command the mappings call under the hood. You can use it directly
+and prefix it with a count to target a specific terminal. This function also takes
+a the `size` and `dir` as an argument e.g.
+
+```vim
+:ToggleTerm size=40 dir=~/Desktop
+```
+
+If specified on creation toggle term will open at the specified directory at the
+specified height.
+
+_NOTE_: If the terminal has already been opened at a particular directory it will
+remain in that dir
+
+### `TermExec`
+
+This command allows you to open a terminal with a specific action.
+e.g. `2TermExec git status` will run git status in terminal 2.
 
 ### Set terminal shading
 
@@ -122,18 +145,6 @@ in your statusline
 " this is pseudo code
 let statusline .= '%{&ft == "toggleterm" ? "terminal (".b:toggle_number.")" : ""}'
 ```
-
-This plugin provides 2 commands
-
-### `ToggleTerm`
-
-This is the command the mappings call under the hood. You can use it directly
-and prefix it with a count to target a specific terminal.
-
-### `TermExec`
-
-This command allows you to open a terminal with a specific action.
-e.g. `2TermExec git status` will run git status in terminal 2.
 
 ### Custom commands
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ A _neovim_ plugin to persist and toggle multiple terminals during an editing ses
 
 ![vertical orientation](./github/vertical-terms.png)
 
+### Send commands to different terminals
+
+![exec](https://user-images.githubusercontent.com/22454918/112119367-36d1e980-8bb5-11eb-9787-5936391127a3.gif)
+
 ## Why?
 
 Neovim's terminal is a very cool, but not super ergonomic tool to use. I find that I often want to
@@ -27,8 +31,6 @@ much more stable alternatives.
 
 I wrote this initially in vimscript as part of my `init.vim`. I then realised I wanted to extend the functionality,
 but didn't want to end up maintaining a bunch of vimscript I had just managed to hack into place 🤷.
-
-It sort of works fine for the exact use case above, but there are undoubtedly some niggling bugs.
 
 ## Roadmap
 

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -447,7 +447,10 @@ end
 function M.exec_command(args, count)
   vim.validate {args = {args, "string"}}
   if not args:match("cmd") then
-    return echomsg("TermExec requires a cmd specified using the syntax cmd='ls -l'", "ErrorMsg")
+    return echomsg(
+      "TermExec requires a cmd specified using the syntax cmd='ls -l' e.g. TermExec cmd='ls -l'",
+      "ErrorMsg"
+    )
   end
   local parsed = parse_input(args)
   vim.validate {

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -97,6 +97,9 @@ local function parse_input(args)
   local result = {}
   if args then
     -- extract the quoted command then remove it from the rest of the argument string
+    -- \v - very magic, reduce the amount of escaping needed
+    -- \w+\= - match a word followed by an = sign
+    -- ("([^"]*)"|'([^']*)') - match double or single quoted text
     -- @see: https://stackoverflow.com/a/5950910
     local regex = [[\v\w+\=%("([^"]*)"|'([^']*)')]]
     local quoted_arg = fn.matchstr(args, regex, "g")

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -38,6 +38,11 @@ function M.save_window_size()
   persistent.height = vim.fn.winheight(0)
 end
 
+local function echomsg(msg, hl)
+  hl = hl or "Title"
+  api.nvim_echo({{msg, hl}}, true, {})
+end
+
 --- Get the size of the split. Order of priority is as follows:
 ---   1. The size argument is a valid number > 0
 ---   2. There is persistent width/height information from prev open state
@@ -441,6 +446,9 @@ end
 
 function M.exec_command(args, count)
   vim.validate {args = {args, "string"}}
+  if not args:match("cmd") then
+    return echomsg("TermExec requires a cmd specified using the syntax cmd='ls -l'", "ErrorMsg")
+  end
   local parsed = parse_input(args)
   vim.validate {
     cmd = {parsed.cmd, "string"},

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -418,16 +418,15 @@ function M.open(num, size, directory)
   end
 end
 
-function M.exec_command(args)
+function M.exec_command(args, count)
   vim.validate {args = {args, "string"}}
-  local num = vim.v.count
   local parsed = parse_input(args)
   vim.validate {
     cmd = {parsed.cmd, "string"},
     dir = {parsed.dir, "string", true},
     size = {parsed.size, "number", true}
   }
-  M.exec(parsed.cmd, num, parsed.size, parsed.dir)
+  M.exec(parsed.cmd, count, parsed.size, parsed.dir)
 end
 
 --- @param cmd string
@@ -507,8 +506,7 @@ function M.__apply_colors()
   end
 end
 
-function M.toggle_command(args)
-  local count = vim.v.count < 1 and 1 or vim.v.count
+function M.toggle_command(args, count)
   local parsed = parse_input(args)
   vim.validate {
     size = {parsed.size, "string", true},

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -71,8 +71,14 @@ end
 local function parse_args(args)
   local result = {}
   if args then
+    -- exract the quoted command then remove it
+    -- from the rest of the argument string
+    local cmd_pattern = [[cmd="([^"]+)"]]
+    result.cmd = string.match(args, cmd_pattern)
+    args = args:gsub(cmd_pattern, "")
+
     local parts = vim.split(args, " ")
-    for _, part in pairs(parts) do
+    for _, part in ipairs(parts) do
       local arg = vim.split(part, "=")
       if #arg > 1 then
         result[arg[1]] = arg[2]
@@ -557,11 +563,6 @@ function M.setup(user_prefs)
     )
   end
   create_augroups({ToggleTerminal = autocommands})
-end
-
---- FIXME this shows a cached version of the terminals
-function M.introspect()
-  print("All terminals: " .. vim.inspect(terminals))
 end
 
 return M

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -96,13 +96,13 @@ end
 local function parse_input(args)
   local result = {}
   if args then
-    -- exract the quoted command then remove it from the rest of the argument string
+    -- extract the quoted command then remove it from the rest of the argument string
     -- @see: https://stackoverflow.com/a/5950910
     local regex = [[\v\w+\=%("([^"]*)"|'([^']*)')]]
     local quoted_arg = fn.matchstr(args, regex, "g")
     args = fn.substitute(args, regex, "", "g")
-
     parse_argument(quoted_arg, result)
+
     local parts = vim.split(args, " ")
     for _, part in ipairs(parts) do
       parse_argument(part, result)

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -446,10 +446,11 @@ function M.exec(cmd, num, size, dir)
     M.open(num, size, dir)
   end
   term, created = find_term(num)
-  local term_cmd = "clear" .. "\n"
+  local term_cmd = ""
   if not created and dir then
     term_cmd = term_cmd .. "cd " .. dir .. "\n"
   end
+  term_cmd = term_cmd .. "clear" .. "\n"
   fn.chansend(term.job_id, term_cmd .. cmd .. "\n")
   vim.cmd("normal! G")
   vim.cmd("wincmd p")

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -387,23 +387,34 @@ function M.open(num, size, directory)
   end
 end
 
---- @param args string
-function M.exec(args)
+function M.exec_command(args)
   vim.validate {args = {args, "string"}}
   local num = vim.v.count
   local parsed = parse_args(args)
   vim.validate {
     cmd = {parsed.cmd, "string"},
-    dir = {parsed.dir, "string", true},
+    dir = {parsed.dir, "string", true}
+  }
+  M.exec(parsed.cmd, num, parsed.size, parsed.dir)
+end
+
+--- @param cmd string
+--- @param num number
+--- @param size number
+function M.exec(cmd, num, size, dir)
+  vim.validate {
+    cmd = {cmd, "string"},
+    num = {num, "number"},
+    size = {size, "number", true}
   }
   -- count
   num = num < 1 and 1 or num
   local term = find_term(num)
   if not find_window(term.window) then
-    M.open(num, parsed.size, parsed.dir)
+    M.open(num, size, dir)
   end
   term = find_term(num)
-  fn.chansend(term.job_id, "clear" .. "\n" .. parsed.cmd .. "\n")
+  fn.chansend(term.job_id, "clear" .. "\n" .. cmd .. "\n")
   vim.cmd("normal! G")
   vim.cmd("wincmd p")
   vim.cmd("stopinsert!")
@@ -459,15 +470,7 @@ function M.__apply_colors()
   end
 end
 
---- If a count is provided we operate on the specific terminal buffer
---- i.e. 2ToggleTerm => open or close Term 2
---- if the count is 1 we use a heuristic which is as follows
---- if there is no open terminal window we toggle the first one i.e. assumed
---- to be the primary. However if several are open we close them.
---- this can be used with the count commands to allow specific operations
---- per term or mass actions
---- @param args string
-function M.toggle(args)
+function M.toggle_command(args)
   local count = vim.v.count < 1 and 1 or vim.v.count
   local parsed = parse_args(args)
   vim.validate {
@@ -477,10 +480,28 @@ function M.toggle(args)
   if parsed.size then
     parsed.size = tonumber(parsed.size)
   end
+  M.toggle(count, parsed.size, parsed.dir)
+end
+
+--- If a count is provided we operate on the specific terminal buffer
+--- i.e. 2ToggleTerm => open or close Term 2
+--- if the count is 1 we use a heuristic which is as follows
+--- if there is no open terminal window we toggle the first one i.e. assumed
+--- to be the primary. However if several are open we close them.
+--- this can be used with the count commands to allow specific operations
+--- per term or mass actions
+--- @param count number
+--- @param size number
+--- @param dir string
+function M.toggle(count, size, dir)
+  vim.validate {
+    count = {count, "number", true},
+    size = {size, "number", true}
+  }
   if count > 1 then
-    toggle_nth_term(count, parsed.size, parsed.dir)
+    toggle_nth_term(count, size, dir)
   else
-    smart_toggle(count, parsed.size, parsed.dir)
+    smart_toggle(count, size, dir)
   end
 end
 

--- a/plugin/toggleterm.vim
+++ b/plugin/toggleterm.vim
@@ -9,5 +9,5 @@ endif
 " Commands
 "--------------------------------------------------------------------------------
 " count defaults to 1
-command! -count=1 -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec_command(<q-args>)
-command! -count=1 -nargs=* ToggleTerm lua require'toggleterm'.toggle_command(<q-args>)
+command! -count=1 -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec_command(<q-args>, <count>)
+command! -count=1 -nargs=* ToggleTerm lua require'toggleterm'.toggle_command(<q-args>, <count>)

--- a/plugin/toggleterm.vim
+++ b/plugin/toggleterm.vim
@@ -10,4 +10,4 @@ endif
 "--------------------------------------------------------------------------------
 " count defaults to 1
 command! -count=1 -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec(<q-args>, <count>)
-command! -count=1 ToggleTerm lua require'toggleterm'.toggle(<count>)
+command! -count=1 -nargs=* ToggleTerm lua require'toggleterm'.toggle(<f-args>)

--- a/plugin/toggleterm.vim
+++ b/plugin/toggleterm.vim
@@ -9,5 +9,5 @@ endif
 " Commands
 "--------------------------------------------------------------------------------
 " count defaults to 1
-command! -count=1 -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec_command(<q-args>)
+command! -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec_command(<q-args>)
 command! -count=1 -nargs=* ToggleTerm lua require'toggleterm'.toggle_command(<q-args>)

--- a/plugin/toggleterm.vim
+++ b/plugin/toggleterm.vim
@@ -9,5 +9,5 @@ endif
 " Commands
 "--------------------------------------------------------------------------------
 " count defaults to 1
-command! -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec_command(<q-args>)
+command! -count=1 -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec_command(<q-args>)
 command! -count=1 -nargs=* ToggleTerm lua require'toggleterm'.toggle_command(<q-args>)

--- a/plugin/toggleterm.vim
+++ b/plugin/toggleterm.vim
@@ -9,5 +9,5 @@ endif
 " Commands
 "--------------------------------------------------------------------------------
 " count defaults to 1
-command! -count=1 -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec(<q-args>)
-command! -count=1 -nargs=* ToggleTerm lua require'toggleterm'.toggle(<q-args>)
+command! -count=1 -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec_command(<q-args>)
+command! -count=1 -nargs=* ToggleTerm lua require'toggleterm'.toggle_command(<q-args>)

--- a/plugin/toggleterm.vim
+++ b/plugin/toggleterm.vim
@@ -9,5 +9,5 @@ endif
 " Commands
 "--------------------------------------------------------------------------------
 " count defaults to 1
-command! -count=1 -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec(<q-args>, <count>)
-command! -count=1 -nargs=* ToggleTerm lua require'toggleterm'.toggle(<f-args>)
+command! -count=1 -complete=shellcmd -nargs=* TermExec lua require'toggleterm'.exec(<q-args>)
+command! -count=1 -nargs=* ToggleTerm lua require'toggleterm'.toggle(<q-args>)


### PR DESCRIPTION
This PR adds the ability to open toggle term to a specific directory.
e.g.
```vim
:ToggleTerm size=25 dir=~/.dotfiles
```
It required a bit of a refactor so I could specify the opening directory and differentiate it from other args like size. Unfortunately the `lua`,`viml` command declaration is a bit rough atm, so the current implentation was the best workaround I could find.

Unfortunately the tradeoff is that using `:TermExec` now works like
```vim
:TermExec size=30 cmd="git status" dir=~/work-repo
```
Since distinguishing the size and dir from the command would have been tough otherwise

Fixes #4. 