### PR TITLE
         Refactor: Create terminal class API

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,31 @@
+---
+name: Run tests
+on:
+  pull_request: ~
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    name: Run tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - run: date +%F > todays-date
+      - name: Restore cache for today's nightly.
+        uses: actions/cache@v2
+        with:
+          path: _neovim
+          key: ${{ runner.os }}-x64-${{ hashFiles('todays-date') }}
+
+      - name: Prepare plenary
+        run: |
+          git clone --depth 1 https://github.com/nvim-lua/plenary.nvim ~/.local/share/nvim/site/pack/vendor/start/plenary.nvim
+          ln -s $(pwd) ~/.local/share/nvim/site/pack/vendor/start
+      - name: Run tests
+        run: |
+          curl -OL https://raw.githubusercontent.com/norcalli/bot-ci/master/scripts/github-actions-setup.sh
+          source github-actions-setup.sh nightly-x64
+          nvim --headless --noplugin -u tests/minimal.vim -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal.vim'}"

--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@ A _neovim_ plugin to persist and toggle multiple terminals during an editing ses
 
 ![screenshot](./github/toggleterm.gif "Toggleterm in action")
 
-### Orientation (vertical or horizontal)
+### Multiple orientations
+
+- **Vertical**
 
 ![vertical orientation](./github/vertical-terms.png)
+
+- **Window**
+
+![window orientation](https://user-images.githubusercontent.com/22454918/114622544-00642780-9ca6-11eb-950f-fef95f9a49af.gif)
 
 ### Send commands to different terminals
 
@@ -62,7 +68,7 @@ require"toggleterm".setup{
   shading_factor = '<number>', -- the degree by which to darken to terminal colour, default: 1 for dark backgrounds, 3 for light
   start_in_insert = true,
   persist_size = true,
-  direction = 'vertical' | 'horizontal',
+  direction = 'vertical' | 'horizontal' | 'window',
 }
 ```
 
@@ -144,6 +150,26 @@ require'toggleterm'.setup{
 }
 ```
 
+### Advanced (Unstable)
+
+Toggleterm also exposes the `Terminal` class so that this can be used to create custom terminals
+e.g.
+
+```lua
+local Terminal = require('toggleterm.terminal').Terminal
+Terminal:new {
+  cmd =  string
+  direction = string
+  dir = string
+  on_stdout = fun(job: number, exit_code: number, type: string)
+  on_stderr = fun(job: number, data: string[], name: string)
+  on_exit = fun(job: number, data: string[], name: string)
+}:toggle()
+```
+
+NOTE: this API is still being fleshed out so is a little unstable, please _Do Not
+Set_ the other terminal fields as these are used internally.
+
 ### Statusline
 
 In order to tell each terminal apart you can use the terminal buffer variable `b:toggle_number`
@@ -161,14 +187,4 @@ You can create your on commands by using the lua functions this plugin provides 
 ```vim
 command! -count=1 TermGitPush  lua require'toggleterm'.exec("git push",    <count>, 12)
 command! -count=1 TermGitPushF lua require'toggleterm'.exec("git push -f", <count>, 12)
-```
-
-or in lua:
-
-```lua
-function _G.term_git_push()
-  require('toggleterm').exec("git push", vim.v.count, 20)
-end
-
-vim.api.nvim_set_keymap("n", "<map>", [[<cmd>lua _G.term_git_push()]], {silent = true, noremap = true})
 ```

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -210,13 +210,17 @@ function M.exec(cmd, num, size, dir)
   vim.validate {
     cmd = {cmd, "string"},
     num = {num, "number"},
-    size = {size, "number", true}
+    size = {size, "number", true},
+    dir = {dir, "string", true}
   }
+  if dir then
+    dir = fn.expand(dir)
+  end
   -- count
   num = num < 1 and 1 or num
   local term, created = get_term(num, dir)
   if not term:is_open() then
-    term:open(size)
+    term:open(size, created)
   end
   if not created and dir then
     term:change_dir(dir)

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -12,12 +12,10 @@ local T = require("toggleterm.terminal")
 
 ---@type Terminal
 local Terminal = T.Terminal
----@type Terminal[]
-local terminals = T.terminals
+---@type fun(): Terminal[]
+local get_all = T.get_all
 ---@type fun(id: integer, directory: string, direction: string): Terminal
 local get_term = T.get_or_create_term
----@type fun(id: integer, term: Terminal, on_add: fun(term: Terminal, num: number)): Terminal,number
-local set_term = T.add
 
 local term_ft = constants.term_ft
 local SHADING_AMOUNT = constants.shading_amount
@@ -135,6 +133,7 @@ local function smart_toggle(_, size, directory, direction)
   if not ui.find_open_windows() then
     get_term(1, directory, direction):open(size)
   else
+    local terminals = get_all()
     local target = #terminals
     -- count backwards from the end of the list
     for i = #terminals, 1, -1 do
@@ -177,17 +176,14 @@ end
 
 function M.on_term_open()
   local id = T.identify(fn.bufname())
-  set_term(
-    id,
+  if id then
     Terminal:new {
+      id = id,
       bufnr = api.nvim_get_current_buf(),
       window = api.nvim_get_current_win(),
       job_id = vim.b.terminal_job_id
-    },
-    function(term)
-      term:__resurrect(term.window, term.bufnr)
-    end
-  )
+    }:__resurrect()
+  end
 end
 
 function M.exec_command(args, count)

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -225,10 +225,7 @@ function M.exec(cmd, num, size, dir)
   if not created and dir then
     term:change_dir(dir)
   end
-  term:send(cmd)
-  vim.cmd("normal! G")
-  vim.cmd("wincmd p")
-  vim.cmd("stopinsert!")
+  term:send(cmd, true)
 end
 
 function M.toggle_command(args, count)

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -131,8 +131,7 @@ end
 --- @param size number
 local function toggle_nth_term(num, size, directory)
   local term = get_term(num, directory)
-
-  ui.update_origin_win(term.window)
+  ui.update_origin_window(term.window)
 
   if ui.find_window(term.window) then
     M.close(num)

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -16,6 +16,8 @@ local Terminal = T.Terminal
 local terminals = T.terminals
 ---@type fun(id: integer, directory: string, direction: string): Terminal
 local get_term = T.get_or_create_term
+---@type fun(id: integer, term: Terminal, on_add: fun(term: Terminal, num: number)): Terminal,number
+local set_term = T.add
 
 local term_ft = constants.term_ft
 local SHADING_AMOUNT = constants.shading_amount
@@ -174,15 +176,16 @@ function M.close_last_window()
 end
 
 function M.on_term_open()
-  T.add(
-    T.identify(fn.bufname()),
+  local id = T.identify(fn.bufname())
+  set_term(
+    id,
     Terminal:new {
       bufnr = api.nvim_get_current_buf(),
       window = api.nvim_get_current_win(),
       job_id = vim.b.terminal_job_id
     },
     function(term)
-      term:resize()
+      term:__resurrect(term.window, term.bufnr)
     end
   )
 end

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -142,20 +142,13 @@ end
 
 function M.close_last_window()
   local buf = api.nvim_get_current_buf()
+  local _, term = T.identify(api.nvim_buf_get_name(buf))
   local only_one_window = fn.winnr("$") == 1
   if only_one_window and vim.bo[buf].filetype == term_ft then
-    -- Reset the window id so there are no hanging
-    -- references to the terminal window
-    for _, term in pairs(terminals) do
-      if term.bufnr == buf then
-        term.window = -1
-        break
-      end
+    if term:is_split() then
+      term:close()
+      vim.cmd("keepalt bnext")
     end
-    -- FIXME switching causes the buffer
-    -- switched to to have no highlighting
-    -- no idea why
-    vim.cmd("keepalt bnext")
   end
 end
 

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -133,7 +133,7 @@ local function toggle_nth_term(num, size, directory)
   local term = get_term(num, directory)
   ui.update_origin_window(term.window)
 
-  if ui.find_window(term.window) then
+  if term:is_open() then
     M.close(num)
   else
     M.open(num, size, directory)
@@ -211,7 +211,7 @@ function M.exec(cmd, num, size, dir)
   num = num < 1 and 1 or num
   local term = get_term(num, dir)
   local created = false
-  if not ui.find_window(term.window) then
+  if not term:is_open() then
     M.open(num, size, dir)
   end
   --- TODO: find a way to do this without calling this function twice

--- a/lua/toggleterm.lua
+++ b/lua/toggleterm.lua
@@ -8,14 +8,14 @@ local config = require("toggleterm.config")
 local utils = require("toggleterm.utils")
 local ui = require("toggleterm.ui")
 
-local T = require("toggleterm.terminal")
+local terms = require("toggleterm.terminal")
 
 ---@type Terminal
-local Terminal = T.Terminal
+local Terminal = terms.Terminal
 ---@type fun(): Terminal[]
-local get_all = T.get_all
+local get_all = terms.get_all
 ---@type fun(id: integer, directory: string, direction: string): Terminal
-local get_term = T.get_or_create_term
+local get_term = terms.get_or_create_term
 
 local term_ft = constants.term_ft
 local SHADING_AMOUNT = constants.shading_amount
@@ -164,7 +164,7 @@ end
 
 function M.close_last_window()
   local buf = api.nvim_get_current_buf()
-  local _, term = T.identify(api.nvim_buf_get_name(buf))
+  local _, term = terms.identify(api.nvim_buf_get_name(buf))
   local only_one_window = fn.winnr("$") == 1
   if only_one_window and vim.bo[buf].filetype == term_ft then
     if term:is_split() then
@@ -175,7 +175,7 @@ function M.close_last_window()
 end
 
 function M.on_term_open()
-  local id = T.identify(fn.bufname())
+  local id = terms.identify(fn.bufname())
   if id then
     Terminal:new {
       id = id,
@@ -302,7 +302,7 @@ function M.setup(user_prefs)
           -- is re-applied
           "ColorScheme",
           "*",
-          string.format("lua require'toggleterm'.__set_highlights(%d)", amount)
+          fmt("lua require'toggleterm'.__set_highlights(%d)", amount)
         },
         {
           "TermOpen",

--- a/lua/toggleterm/config.lua
+++ b/lua/toggleterm/config.lua
@@ -1,0 +1,31 @@
+local M = {}
+
+local config = {
+  size = 12,
+  shade_filetypes = {},
+  shade_terminals = true,
+  insert_mappings = true,
+  start_in_insert = true,
+  persist_size = true,
+  direction = "horizontal",
+  shading_factor = nil
+}
+
+--- get the full user config or just a specified value
+---@param key string
+---@return table | string | number
+function M.get(key)
+  if key and config[key] then
+    return config[key]
+  end
+  return config
+end
+
+function M.set(user_conf)
+  if user_conf and type(user_conf) == "table" then
+    config = vim.tbl_deep_extend("force", config, user_conf)
+  end
+  return config
+end
+
+return M

--- a/lua/toggleterm/constants.lua
+++ b/lua/toggleterm/constants.lua
@@ -1,0 +1,9 @@
+local M = {}
+-----------------------------------------------------------
+-- Constants
+-----------------------------------------------------------
+M.term_ft = "toggleterm"
+-- -30 is a magic number based on manual testing of what looks good
+M.shading_amount = -30
+
+return M

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -1,0 +1,217 @@
+local M = {}
+
+local ui = require("toggleterm.ui")
+local config = require("toggleterm.config")
+local utils = require("toggleterm.utils")
+local term_ft = require("toggleterm.constants").term_ft
+
+local api = vim.api
+local fmt = string.format
+local fn = vim.fn
+
+--- @param bufnr number
+local function setup_buffer_mappings(bufnr)
+  local mapping = config.get("open_mapping")
+  if mapping then
+    api.nvim_buf_set_keymap(
+      bufnr,
+      "t",
+      mapping,
+      '<C-\\><C-n>:exe v:count1 . "ToggleTerm"<CR>',
+      {
+        silent = true,
+        noremap = true
+      }
+    )
+  end
+end
+
+---Terminal buffer autocommands
+---@param term Terminal
+local function setup_buffer_autocommands(term)
+  local conf = config.get()
+  local commands = {
+    {
+      "TermClose",
+      fmt("<buffer=%d>", term.bufnr),
+      fmt('lua require"toggleterm.terminal".delete(%d)', term.id)
+    }
+  }
+
+  if conf.start_in_insert then
+    vim.cmd("startinsert!")
+    table.insert(
+      commands,
+      {
+        "BufEnter",
+        fmt("<buffer=%d>", term.bufnr),
+        "startinsert!"
+      }
+    )
+  end
+  if conf.persist_size and term:is_split() then
+    table.insert(
+      commands,
+      {
+        "CursorHold",
+        fmt("<buffer=%d>", term.bufnr),
+        "lua require'toggleterm'.save_window_size()"
+      }
+    )
+  end
+  utils.create_augroups({["ToggleTerm" .. term.bufnr] = commands})
+end
+
+--- @class Terminal
+--- @field cmd string
+--- @field direction string
+--- @field id number
+--- @field bufnr number
+--- @field window number
+--- @field job_id number
+--- @field dir string
+M.Terminal = {}
+
+---Create a new terminal object
+---@param term Terminal
+---@return Terminal
+function M.Terminal:new(term)
+  local conf = config.get()
+  assert(term.id, "A terminal id must be specified")
+  term = term or {}
+  self.__index = self
+  term.direction = term.direction or conf.direction
+  term.window = term.window or -1
+  term.job_id = term.job_id or -1
+  term.bufnr = term.bufnr or -1
+  term.dir = term.dir or vim.loop.cwd()
+  term.id = term.id
+  return setmetatable(term, self)
+end
+
+function M.Terminal:is_split()
+  return self.direction == "vertical" or self.direction == "horizontal"
+end
+
+function M.Terminal:resize(size)
+  if self:is_split() then
+    vim.cmd(self.direction == "vertical" and "vertical resize" or "resize" .. " " .. size)
+  end
+end
+
+function M.Terminal:close()
+  ui.update_origin_window(self.window)
+  if ui.find_window(self.window) then
+    if self:is_split() then
+      ui.save_size()
+      vim.cmd("hide")
+      local origin = ui.get_origin_window()
+      if api.nvim_win_is_valid(origin) then
+        api.nvim_set_current_win(origin)
+      else
+        ui.set_origin_window(nil)
+      end
+    else
+      vim.cmd("b#")
+    end
+
+    vim.cmd("stopinsert!")
+  else
+    if self.id then
+      vim.cmd(fmt('echoerr "Failed to close window: %d does not exist"', self.id))
+    else
+      vim.cmd('echoerr "Failed to close window: invalid term number"')
+    end
+  end
+end
+
+---Send a command to a running terminal
+---@param cmd any
+function M.Terminal:send(cmd)
+  fn.chansend(self.job_id, cmd)
+end
+
+---Update the directory of an already opened terminal
+---@param dir string
+function M.Terminal:change_dir(dir)
+  if self.dir ~= dir then
+    self:send("cd " .. dir .. "\n" .. "clear" .. "\n")
+  end
+end
+
+---Open a terminal window
+---@param size number
+---@param is_new boolean
+function M.Terminal:open(size, is_new)
+  ui.set_origin_window()
+  if not api.nvim_buf_is_loaded(self.bufnr) then
+    self.window = api.nvim_get_current_win()
+    self.bufnr = api.nvim_create_buf(false, false)
+    self:toggle(size, self)
+
+    api.nvim_set_current_buf(self.bufnr)
+    api.nvim_win_set_buf(self.window, self.bufnr)
+
+    local name = vim.o.shell .. ";#" .. term_ft .. "#" .. self.id
+    self.job_id = fn.termopen(name, {detach = 1, cwd = self.dir})
+
+    setup_buffer_autocommands(self)
+    setup_buffer_mappings(self.bufnr)
+    M.terminals[self.id] = self
+  else
+    self:toggle(size, self)
+    self.window = api.nvim_get_current_win()
+    if not is_new then
+      self:change_dir(self.dir)
+    end
+  end
+end
+
+---Open a terminal in a type of window i.e. a split,full window or tab
+---@param size number
+---@param term table
+function M.Terminal:toggle(size, term)
+  local dir = self.direction
+  if dir == "horizontal" or dir == "vertical" then
+    ui.open_split(size)
+  elseif dir == "window" then
+    ui.open_window(term.bufnr)
+  elseif dir == "tab" then
+    ui.open_tab()
+  end
+end
+
+---Add a terminal to the list of terminals, if it does not exist add nothing
+---@param num number
+---@param term Terminal
+---@param on_add fun(term: Terminal, num: number):nil
+function M.add(num, term, on_add)
+  if not M.terminals[num] then
+    M.terminals[num] = term
+    if on_add then
+      on_add(term, num)
+    else
+      return term, num
+    end
+  end
+  return nil, num
+end
+
+--- get the toggle term number from
+--- the name e.g. term://~/.dotfiles//3371887:/usr/bin/zsh;#toggleterm#1
+--- the number in this case is 1
+--- @param name string
+function M.identify(name)
+  local parts = vim.split(name, "#")
+  return tonumber(parts[#parts])
+end
+
+--- Remove the in memory reference to the no longer open terminal
+--- @param num string
+function M.delete(num)
+  if M.terminals[num] then
+    M.terminals[num] = nil
+  end
+end
+
+return M

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -119,7 +119,9 @@ function Terminal:is_split()
 end
 
 function Terminal:resize(size)
-  ui.resize_split(self, size)
+  if self:is_split() then
+    ui.resize_split(self, size)
+  end
 end
 
 function Terminal:is_open()

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -160,9 +160,16 @@ local function with_cr(...)
 end
 
 ---Send a command to a running terminal
----@vararg string
-function Terminal:send(...)
-  fn.chansend(self.job_id, with_cr(...))
+---@param cmd string|string[]
+---@param go_back boolean whether or not to return to original window
+function Terminal:send(cmd, go_back)
+  cmd = type(cmd) == "table" and with_cr(unpack(cmd)) or with_cr(cmd)
+  fn.chansend(self.job_id, cmd)
+  if go_back then
+    ui.scroll_to_bottom()
+    ui.goto_previous()
+    ui.stopinsert()
+  end
 end
 
 function Terminal:clear()
@@ -173,7 +180,7 @@ end
 ---@param dir string
 function Terminal:change_dir(dir)
   if self.dir ~= dir then
-    self:send(fmt("cd %s", dir), "clear")
+    self:send({fmt("cd %s", dir), "clear"})
   end
 end
 

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -148,21 +148,32 @@ function Terminal:shutdown()
   ui.delete_buf(self)
 end
 
+---Combine arguments into strings separated by new lines
+---@vararg string
+---@return string
+local function with_cr(...)
+  local result = {}
+  for _, str in ipairs({...}) do
+    table.insert(result, str .. "\n")
+  end
+  return table.concat(result, "")
+end
+
 ---Send a command to a running terminal
----@param cmd string
-function Terminal:send(cmd)
-  fn.chansend(self.job_id, cmd .. "\n")
+---@vararg string
+function Terminal:send(...)
+  fn.chansend(self.job_id, with_cr(...))
 end
 
 function Terminal:clear()
-  self:send("clear" .. "\n")
+  self:send("clear")
 end
 
 ---Update the directory of an already opened terminal
 ---@param dir string
 function Terminal:change_dir(dir)
   if self.dir ~= dir then
-    self:send("cd " .. dir .. "\n" .. "clear" .. "\n")
+    self:send(fmt("cd %s", dir), "clear")
   end
 end
 

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -21,6 +21,9 @@ local terminals = {}
 --- @field job_id number
 --- @field dir string
 --- @field name string
+--- @field on_stdout fun(job: number, exit_code: number, type: string)
+--- @field on_stderr fun(job: number, data: string[], name: string)
+--- @field on_exit fun(job: number, data: string[], name: string)
 local Terminal = {}
 
 local function next_id()
@@ -98,6 +101,9 @@ function Terminal:new(term)
   term.bufnr = term.bufnr or -1
   term.dir = term.dir or vim.loop.cwd()
   term.id = term.id or next_id()
+  term.on_stdout = term.on_stdout
+  term.on_stderr = term.on_stderr
+  term.on_exit = term.on_exit
   return setmetatable(term, self)
 end
 

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -184,16 +184,15 @@ end
 ---@param num number
 ---@param term Terminal
 ---@param on_add fun(term: Terminal, num: number):nil
+---@return Terminal, number
 function M.add(num, term, on_add)
   if not terminals[num] then
     terminals[num] = term
     if on_add then
       on_add(term, num)
-    else
-      return term, num
     end
   end
-  return nil, num
+  return terminals[num], num
 end
 
 --- get the toggle term number from

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -186,6 +186,16 @@ function Terminal:open(size, is_new)
   end
 end
 
+---Open if closed and close if opened
+---@param size number
+function Terminal:toggle(size)
+  if self:is_open() then
+    self:close()
+  else
+    self:open(size)
+  end
+end
+
 ---Add a terminal to the list of terminals, if it does not exist add nothing
 ---@param num number
 ---@param term Terminal
@@ -225,11 +235,11 @@ end
 ---@param dir string
 ---@return Terminal
 ---@return boolean
-function M.get_or_create_term(num, dir)
+function M.get_or_create_term(num, dir, direction)
   if terminals[num] then
     return terminals[num], false
   end
-  return Terminal:new {id = next_id(), dir = dir}, true
+  return Terminal:new {id = next_id(), dir = dir, direction = direction}, true
 end
 
 M.Terminal = Terminal

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -150,6 +150,15 @@ function Terminal:__spawn()
   self.name = name
 end
 
+---@private
+---Add an orphaned terminal to the list of terminal and re-apply settings
+---@param win number
+---@param buf number
+function Terminal:__resurrect(win, buf)
+  ui.set_options(win, buf, self)
+  self:resize()
+end
+
 ---Open a terminal in a type of window i.e. a split,full window or tab
 ---@param size number
 ---@param term table

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -200,9 +200,11 @@ end
 --- the name e.g. term://~/.dotfiles//3371887:/usr/bin/zsh;#toggleterm#1
 --- the number in this case is 1
 --- @param name string
+--- @return number
 function M.identify(name)
   local parts = vim.split(name, "#")
-  return tonumber(parts[#parts])
+  local id = tonumber(parts[#parts])
+  return id, terminals[id]
 end
 
 --- Remove the in memory reference to the no longer open terminal

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -172,8 +172,7 @@ function Terminal:open(size, is_new)
     M.add(self.id, self)
   else
     open_by_type(size, self)
-    -- don't change the alternate buffer so that <c-^><c-^> does nothing in the terminal split
-    vim.cmd(fmt("keepalt buffer %d", self.bufnr))
+    ui.switch_buf(self.bufnr)
     self.window = api.nvim_get_current_win()
     if not is_new then
       self:change_dir(self.dir)

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -224,7 +224,7 @@ function Terminal:open(size, is_new)
     self:__spawn()
     setup_buffer_autocommands(self)
     setup_buffer_mappings(self.bufnr)
-    M.add(self.id, self)
+    self:__add()
   else
     opener(size, self)
     ui.switch_buf(self.bufnr)
@@ -244,21 +244,6 @@ function Terminal:toggle(size)
     self:open(size)
   end
   return self
-end
-
----Add a terminal to the list of terminals, if it does not exist add nothing
----@param num number
----@param term Terminal
----@param on_add fun(term: Terminal, num: number):nil
----@return Terminal, number
-function M.add(num, term, on_add)
-  if not terminals[num] then
-    terminals[num] = term
-    if on_add then
-      on_add(term, num)
-    end
-  end
-  return terminals[num], num
 end
 
 --- get the toggle term number from

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -172,6 +172,7 @@ function Terminal:open(size, is_new)
     M.add(self.id, self)
   else
     open_by_type(size, self)
+    -- don't change the alternate buffer so that <c-^><c-^> does nothing in the terminal split
     vim.cmd(fmt("keepalt buffer %d", self.bufnr))
     self.window = api.nvim_get_current_win()
     if not is_new then

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -133,7 +133,7 @@ function Terminal:close()
 
   if ui.try_open(self.window) then
     ui.close(self)
-    vim.cmd("stopinsert!")
+    ui.stopinsert()
   else
     local msg =
       self.id and fmt("Failed to close window: %d does not exist", self.id) or

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -48,13 +48,15 @@ local function set_opts(win, buf, term)
 end
 
 ---Create a terminal buffer with the correct buffer/window options
+---then set it to current window
 ---@param term Terminal
 ---@return number, number
-function M.create_buffer(term)
+function M.create_buf_and_set(term)
   local window = api.nvim_get_current_win()
   local bufnr = api.nvim_create_buf(false, false)
   set_opts(window, bufnr, term)
   api.nvim_set_current_buf(bufnr)
+  api.nvim_win_set_buf(window, bufnr)
   return window, bufnr
 end
 
@@ -132,17 +134,11 @@ function M.open_split(size, term)
     -- move horizontal split to the bottom
     vim.cmd(commands.position)
   end
-  ---TODO should the resize happen here
   M.resize_split(term, size)
 end
 
 function M.open_tab()
   vim.cmd("tabnew")
-end
-
-function M.open_window(term)
-  term.window, term.bufnr = M.create_buffer(term)
-  -- vim.cmd(fmt("buffer! %d", term.bufnr))
 end
 
 local function close_split()

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -81,6 +81,18 @@ function M.update_origin_window(term_window)
   end
 end
 
+function M.scroll_to_bottom()
+  vim.cmd("normal! G")
+end
+
+function M.goto_previous()
+  vim.cmd("wincmd p")
+end
+
+function M.stopinsert()
+  vim.cmd("stopinsert!")
+end
+
 --- @param win_id number
 --- @return boolean
 function M.try_open(win_id)

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -76,7 +76,8 @@ function M.update_origin_window(term_window)
 end
 
 --- @param win_id number
-function M.find_window(win_id)
+--- @return boolean
+function M.try_open(win_id)
   return fn.win_gotoid(win_id) > 0
 end
 --- Find the first open terminal window

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -1,6 +1,6 @@
 local M = {}
 
-local C = require("toggleterm.constants")
+local constants = require("toggleterm.constants")
 
 local fn = vim.fn
 local fmt = string.format
@@ -23,7 +23,7 @@ end
 --- If `preferences.persist_size = false` then option `2` in the
 --- list is skipped.
 --- @param size number
-local function get_size(size)
+function M.get_size(size)
   local config = require("toggleterm.config").get()
   local valid_size = size ~= nil and size > 0
   if not config.persist_size then
@@ -41,14 +41,13 @@ local function set_opts(term)
     vim.wo[term.window].winfixheight = true
   end
   vim.bo[term.bufnr].buflisted = false
-  vim.bo[term.bufnr].filetype = C.term_ft
+  vim.bo[term.bufnr].filetype = constants.term_ft
   api.nvim_buf_set_var(term.bufnr, "toggle_number", term.id)
 end
 
 function M.set_origin_window()
   origin_window = api.nvim_get_current_win()
 end
-
 
 function M.get_origin_window()
   return origin_window
@@ -61,10 +60,37 @@ function M.update_origin_window(term_window)
   end
 end
 
+--- @param win_id number
+function M.find_window(win_id)
+  return fn.win_gotoid(win_id) > 0
+end
+--- Find the first open terminal window
+--- by iterating all windows and matching the
+--- containing buffers filetype with the passed in
+--- comparator function or the default which matches
+--- the filetype
+--- @param comparator function
+function M.find_open_windows(comparator)
+  comparator = comparator or function(buf)
+      return vim.bo[buf].filetype == constants.term_ft
+    end
+  local wins = api.nvim_list_wins()
+  local is_open = false
+  local term_wins = {}
+  for _, win in pairs(wins) do
+    local buf = api.nvim_win_get_buf(win)
+    if comparator(buf) then
+      is_open = true
+      table.insert(term_wins, win)
+    end
+  end
+  return is_open, term_wins
+end
+
 --- @param size number
---- @param term table
+--- @param term Terminal
 function M.open_split(size, term)
-  size = get_size(size)
+  size = M.get_size(size)
 
   local has_open, win_ids = M.find_open_windows()
   local commands =
@@ -83,7 +109,7 @@ function M.open_split(size, term)
   if has_open then
     -- we need to be in the terminal window most recently opened
     -- in order to split to the right of it
-    fn.win_gotoid(win_ids[#win_ids])
+    api.nvim_set_current_win(win_ids[#win_ids])
     vim.cmd(commands[1])
     vim.cmd(fmt("keepalt buffer %d", term.bufnr))
     vim.wo.winfixheight = true

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -60,6 +60,12 @@ function M.create_buf_and_set(term)
   return window, bufnr
 end
 
+function M.delete_buf(term)
+  if api.nvim_buf_is_valid(term.bufnr) then
+    api.nvim_buf_delete(term.bufnr, {force = true})
+  end
+end
+
 function M.set_origin_window()
   origin_window = api.nvim_get_current_win()
 end
@@ -149,9 +155,13 @@ function M.open_tab()
   vim.cmd("tabnew")
 end
 
-local function close_split()
+---Close terminal window
+---@param term Terminal
+local function close_split(term)
   M.save_window_size()
-  vim.cmd("hide")
+  if api.nvim_win_is_valid(term.window) then
+    api.nvim_win_close(term.window, true)
+  end
   if api.nvim_win_is_valid(origin_window) then
     api.nvim_set_current_win(origin_window)
   else
@@ -167,7 +177,7 @@ end
 ---@param term Terminal
 function M.close(term)
   if term:is_split() then
-    close_split()
+    close_split(term)
   elseif term.direction == "window" then
     close_window()
   else

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -102,6 +102,13 @@ function M.find_open_windows(comparator)
   return is_open, term_wins
 end
 
+---Switch to the given buffer without changing the alternate
+---@param buf number
+function M.switch_buf(buf)
+  -- don't change the alternate buffer so that <c-^><c-^> does nothing in the terminal split
+  vim.cmd(fmt("keepalt buffer %d", buf))
+end
+
 local split_commands = {
   horizontal = {
     existing = "vsplit",
@@ -152,7 +159,7 @@ local function close_split()
 end
 
 local function close_window()
-  vim.cmd("b#")
+  vim.cmd("keepalt b#")
 end
 
 ---Close given terminal's ui

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -38,7 +38,7 @@ end
 --- @param win number
 --- @param buf number
 --- @param term Terminal
-local function set_opts(win, buf, term)
+function M.set_options(win, buf, term)
   if term:is_split() then
     vim.wo[win].winfixheight = true
   end
@@ -54,7 +54,7 @@ end
 function M.create_buf_and_set(term)
   local window = api.nvim_get_current_win()
   local bufnr = api.nvim_create_buf(false, false)
-  set_opts(window, bufnr, term)
+  M.set_options(window, bufnr, term)
   api.nvim_set_current_buf(bufnr)
   api.nvim_win_set_buf(window, bufnr)
   return window, bufnr

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -1,0 +1,107 @@
+local M = {}
+
+local C = require("toggleterm.constants")
+
+local fn = vim.fn
+local fmt = string.format
+local api = vim.api
+
+local persistent = {}
+local origin_window
+
+function M.save_window_size()
+  -- Save the size of the split before it is hidden
+  persistent.width = vim.fn.winwidth(0)
+  persistent.height = vim.fn.winheight(0)
+end
+
+--- Get the size of the split. Order of priority is as follows:
+--- 1. The size argument is a valid number > 0
+--- 2. There is persistent width/height information from prev open state
+--- 3. Default/base case perference size
+---
+--- If `preferences.persist_size = false` then option `2` in the
+--- list is skipped.
+--- @param size number
+local function get_size(size)
+  local config = require("toggleterm.config").get()
+  local valid_size = size ~= nil and size > 0
+  if not config.persist_size then
+    return valid_size and size or config.size
+  end
+
+  local psize = config.direction == "horizontal" and persistent.height or persistent.width
+  return valid_size and size or psize or config.size
+end
+
+--- Add terminal buffer specific options
+--- @param term Terminal
+local function set_opts(term)
+  if term:is_split() then
+    vim.wo[term.window].winfixheight = true
+  end
+  vim.bo[term.bufnr].buflisted = false
+  vim.bo[term.bufnr].filetype = C.term_ft
+  api.nvim_buf_set_var(term.bufnr, "toggle_number", term.id)
+end
+
+function M.set_origin_window()
+  origin_window = api.nvim_get_current_win()
+end
+
+
+function M.get_origin_window()
+  return origin_window
+end
+
+function M.update_origin_window(term_window)
+  local curr_win = api.nvim_get_current_win()
+  if term_window ~= curr_win then
+    origin_window = curr_win
+  end
+end
+
+--- @param size number
+--- @param term table
+function M.open_split(size, term)
+  size = get_size(size)
+
+  local has_open, win_ids = M.find_open_windows()
+  local commands =
+    term.direction == "horizontal" and
+    {
+      "vsplit",
+      "split",
+      "wincmd J"
+    } or
+    {
+      "split",
+      "vsplit",
+      "wincmd L"
+    }
+
+  if has_open then
+    -- we need to be in the terminal window most recently opened
+    -- in order to split to the right of it
+    fn.win_gotoid(win_ids[#win_ids])
+    vim.cmd(commands[1])
+    vim.cmd(fmt("keepalt buffer %d", term.bufnr))
+    vim.wo.winfixheight = true
+  else
+    vim.cmd(size .. commands[2])
+    -- move horizontal split to the bottom
+    vim.cmd(commands[3])
+  end
+  term:resize(size)
+  set_opts(term)
+end
+
+function M.open_tab()
+  vim.cmd("tabnew")
+end
+
+function M.open_window(bufnr)
+  vim.cmd(fmt("buffer! %d", bufnr))
+end
+
+return M

--- a/lua/toggleterm/utils.lua
+++ b/lua/toggleterm/utils.lua
@@ -1,5 +1,12 @@
 local M = {}
 
+local api = vim.api
+
+function M.echomsg(msg, hl)
+  hl = hl or "Title"
+  api.nvim_echo({{msg, hl}}, true, {})
+end
+
 --- Source: https://teukka.tech/luanvim.html
 --- @param definitions table<string,table>
 function M.create_augroups(definitions)

--- a/lua/toggleterm/utils.lua
+++ b/lua/toggleterm/utils.lua
@@ -2,6 +2,9 @@ local M = {}
 
 local api = vim.api
 
+---Print a message to vim's commandline
+---@param msg string
+---@param hl string
 function M.echomsg(msg, hl)
   hl = hl or "Title"
   api.nvim_echo({{msg, hl}}, true, {})

--- a/lua/toggleterm/utils.lua
+++ b/lua/toggleterm/utils.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+--- Source: https://teukka.tech/luanvim.html
+--- @param definitions table<string,table>
+function M.create_augroups(definitions)
+  for group_name, definition in pairs(definitions) do
+    vim.cmd("augroup " .. group_name)
+    vim.cmd("autocmd!")
+    for _, def in pairs(definition) do
+      local command = table.concat(vim.tbl_flatten {"autocmd", def}, " ")
+      vim.cmd(command)
+    end
+    vim.cmd("augroup END")
+  end
+end
+
+return M

--- a/tests/minimal.vim
+++ b/tests/minimal.vim
@@ -1,0 +1,3 @@
+set rtp+=.
+set rtp+=../plenary.nvim
+runtime! plugin/plenary.vim

--- a/tests/terminal_spec.lua
+++ b/tests/terminal_spec.lua
@@ -92,6 +92,25 @@ describe(
     )
 
     describe(
+      "terminal buffers options - ",
+      function()
+        before_each(
+          function()
+            require("toggleterm.config").set {shade_terminals = true}
+          end
+        )
+        it(
+          "terminal is given a winhighlight",
+          function()
+            local test1 = Terminal:new():toggle()
+            local winhighlight = vim.wo[test1.window].winhighlight
+            assert.is.truthy(winhighlight:match("Normal:DarkenedPanel"))
+          end
+        )
+      end
+    )
+
+    describe(
       "executing commands - ",
       function()
         it(

--- a/tests/terminal_spec.lua
+++ b/tests/terminal_spec.lua
@@ -4,6 +4,7 @@ local fn = vim.fn
 local spy = require("luassert.spy")
 
 local toggleterm = require("toggleterm")
+local constants = require("toggleterm.constants")
 
 local ui = require("toggleterm.ui")
 local t = require("toggleterm.terminal")
@@ -100,11 +101,19 @@ describe(
           end
         )
         it(
-          "terminal is given a winhighlight",
+          "should give each terminal a winhighlight",
           function()
             local test1 = Terminal:new():toggle()
             local winhighlight = vim.wo[test1.window].winhighlight
             assert.is.truthy(winhighlight:match("Normal:DarkenedPanel"))
+          end
+        )
+        it(
+          "should set the correct filetype",
+          function()
+            local test1 = Terminal:new():toggle()
+            local ft = vim.bo[test1.bufnr].filetype
+            assert.equals(constants.term_ft, ft)
           end
         )
       end

--- a/tests/terminal_spec.lua
+++ b/tests/terminal_spec.lua
@@ -1,15 +1,85 @@
+local api = vim.api
+
 describe(
   "Terminals",
   function()
-    --- TODO cannot find toggle term
-    require("toggleterm")
-    local T = require("toggleterm.terminal")
-    local Terminal = T.Terminal
-    it(
-      "can add numbers",
+    local toggleterm = require("toggleterm")
+
+    local ui = require("toggleterm.ui")
+    local t = require("toggleterm.terminal")
+
+    ---@type Terminal
+    local Terminal = t.Terminal
+    ---@type Terminal[]
+    local terminals
+
+    ---Return if a terminal has windows
+    ---@param term table
+    ---@return any
+    local function term_has_windows(term)
+      return ui.find_open_windows(
+        function(buf)
+          return buf == term.bufnr
+        end
+      )
+    end
+
+    before_each(
       function()
-        local test = Terminal:new()
-        assert.are.same(test.id, 1)
+        terminals = require("toggleterm.terminal").get_all()
+
+        toggleterm.setup {
+          open_mapping = [[<c-\>]]
+        }
+      end
+    )
+
+    after_each(
+      function()
+        require("toggleterm.terminal").reset()
+      end
+    )
+
+    it(
+      "new terminals are assigned incremental ids",
+      function()
+        local test1 = Terminal:new():toggle()
+        local test2 = Terminal:new():toggle()
+        local test3 = Terminal:new():toggle()
+        assert.are.same(test1.id, 1)
+        assert.are.same(test2.id, 2)
+        assert.are.same(test3.id, 3)
+      end
+    )
+
+    it(
+      "should open a terminal window on toggle",
+      function()
+        local test1 = Terminal:new()
+        test1:toggle()
+        assert.is_true(api.nvim_buf_is_valid(test1.bufnr))
+        assert.is_true(vim.tbl_contains(api.nvim_list_wins(), test1.window))
+      end
+    )
+
+    it(
+      "should close a terminal window if open",
+      function()
+        local test1 = Terminal:new()
+        test1:toggle()
+        assert.is_true(vim.tbl_contains(api.nvim_list_wins(), test1.window))
+        test1:toggle()
+        assert.is_not_true(vim.tbl_contains(api.nvim_list_wins(), test1.window))
+      end
+    )
+
+    it(
+      "should toggle a specific buffer if a count is passed",
+      function()
+        toggleterm.toggle(2, 15)
+        assert.equals(#terminals, 1)
+        local term = terminals[1]
+        assert.is_true(term_has_windows(term))
       end
     )
   end

--- a/tests/terminal_spec.lua
+++ b/tests/terminal_spec.lua
@@ -1,0 +1,16 @@
+describe(
+  "Terminals",
+  function()
+    --- TODO cannot find toggle term
+    require("toggleterm")
+    local T = require("toggleterm.terminal")
+    local Terminal = T.Terminal
+    it(
+      "can add numbers",
+      function()
+        local test = Terminal:new()
+        assert.are.same(test.id, 1)
+      end
+    )
+  end
+)

--- a/tests/terminal_spec.lua
+++ b/tests/terminal_spec.lua
@@ -1,85 +1,104 @@
 local api = vim.api
+local stub = require("luassert.stub")
+local mock = require("luassert.mock")
+
+local toggleterm = require("toggleterm")
+
+local ui = require("toggleterm.ui")
+local t = require("toggleterm.terminal")
+
+---@type Terminal
+local Terminal = t.Terminal
+---@type Terminal[]
+local terminals
+
+---Return if a terminal has windows
+---@param term table
+---@return any
+local function term_has_windows(term)
+  return ui.find_open_windows(
+    function(buf)
+      return buf == term.bufnr
+    end
+  )
+end
 
 describe(
-  "Terminals",
+  "ToggleTerm tests:",
   function()
-    local toggleterm = require("toggleterm")
-
-    local ui = require("toggleterm.ui")
-    local t = require("toggleterm.terminal")
-
-    ---@type Terminal
-    local Terminal = t.Terminal
-    ---@type Terminal[]
-    local terminals
-
-    ---Return if a terminal has windows
-    ---@param term table
-    ---@return any
-    local function term_has_windows(term)
-      return ui.find_open_windows(
-        function(buf)
-          return buf == term.bufnr
-        end
-      )
-    end
-
-    before_each(
+    describe(
+      "core functionality - ",
       function()
-        terminals = require("toggleterm.terminal").get_all()
+        before_each(
+          function()
+            terminals = require("toggleterm.terminal").get_all()
 
-        toggleterm.setup {
-          open_mapping = [[<c-\>]]
-        }
-      end
-    )
+            toggleterm.setup {
+              open_mapping = [[<c-\>]]
+            }
+          end
+        )
 
-    after_each(
-      function()
-        require("toggleterm.terminal").reset()
-      end
-    )
+        after_each(
+          function()
+            require("toggleterm.terminal").reset()
+          end
+        )
 
-    it(
-      "new terminals are assigned incremental ids",
-      function()
-        local test1 = Terminal:new():toggle()
-        local test2 = Terminal:new():toggle()
-        local test3 = Terminal:new():toggle()
-        assert.are.same(test1.id, 1)
-        assert.are.same(test2.id, 2)
-        assert.are.same(test3.id, 3)
-      end
-    )
+        it(
+          "new terminals are assigned incremental ids",
+          function()
+            local test1 = Terminal:new():toggle()
+            local test2 = Terminal:new():toggle()
+            local test3 = Terminal:new():toggle()
+            assert.are.same(test1.id, 1)
+            assert.are.same(test2.id, 2)
+            assert.are.same(test3.id, 3)
+          end
+        )
 
-    it(
-      "should open a terminal window on toggle",
-      function()
-        local test1 = Terminal:new()
-        test1:toggle()
-        assert.is_true(api.nvim_buf_is_valid(test1.bufnr))
-        assert.is_true(vim.tbl_contains(api.nvim_list_wins(), test1.window))
-      end
-    )
+        it(
+          "should open a terminal window on toggle",
+          function()
+            local test1 = Terminal:new()
+            test1:toggle()
+            assert.is_true(api.nvim_buf_is_valid(test1.bufnr))
+            assert.is_true(vim.tbl_contains(api.nvim_list_wins(), test1.window))
+          end
+        )
 
-    it(
-      "should close a terminal window if open",
-      function()
-        local test1 = Terminal:new()
-        test1:toggle()
-        assert.is_true(vim.tbl_contains(api.nvim_list_wins(), test1.window))
-        test1:toggle()
-        assert.is_not_true(vim.tbl_contains(api.nvim_list_wins(), test1.window))
-      end
-    )
+        it(
+          "should close a terminal window if open",
+          function()
+            local test1 = Terminal:new()
+            test1:toggle()
+            assert.is_true(vim.tbl_contains(api.nvim_list_wins(), test1.window))
+            test1:toggle()
+            assert.is_not_true(vim.tbl_contains(api.nvim_list_wins(), test1.window))
+          end
+        )
 
-    it(
-      "should toggle a specific buffer if a count is passed",
-      function()
-        toggleterm.toggle(2, 15)
-        assert.equals(#terminals, 1)
-        local term = terminals[1]
-        assert.is_true(term_has_windows(term))
+        it(
+          "should toggle a specific buffer if a count is passed",
+          function()
+            toggleterm.toggle(2, 15)
+            assert.equals(#terminals, 1)
+            local term = terminals[1]
+            assert.is_true(term_has_windows(term))
+          end
+        )
+
+        ---TODO figure out how to stub class methods
+        pending(
+          "should send commands to a terminal on exec",
+          function()
+            local test1 = Terminal:new():toggle()
+            local m = mock(test1, true)
+            toggleterm.exec('echo "hello world"', 1)
+            assert.stub(m.send).was_called_with('echo "hello world"')
+            mock.revert(test1)
+          end
+        )
       end
     )
   end


### PR DESCRIPTION
This PR refactors a lot of the ad hoc logic from this plugins implementation and encapsulates it into a `Terminal` class, it also re-organises things so that creating new layouts such as opening a `window` or `tab` are easier.

This will also pave the way to having a floating window and a terminal api that users can use via
```lua
local Terminal = require('toggleterm.terminal').Terminal
local lazy_git_term  = Terminal:new{
  cmd = "lazygit",
  direction = "floating",
  dir = "<directory>",
}
lazy_git_term:toggle()
```

### TODO
- [x] toggling with a count should open that specific toggle term 
- [x] toggle term buffers should be resurrected post loading a session
- [x] validate `TermExec` works as expected
- [x] validate terminal size is persisted correctly
- [x] validate opening with existing layouts works
- [x] Add tests

### Moved to Follow up PR(s)
- Add floating window layout
- validate opening with dynamic layout is possible