### PR TITLE
Check if terminal is open in `Terminal:shutdown`

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -162,7 +162,9 @@ function Terminal:close()
 end
 
 function Terminal:shutdown()
-  self:close()
+  if self:is_open() then
+    self:close()
+  end
   ui.delete_buf(self)
 end
 


### PR DESCRIPTION
Check if terminal is open before trying to close it in `Terminal:shutdown`.

Also allows `reset` to run without error even with closed terminals.