### PR TITLE
Add option to give a function for the size

### DIFF
--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -1,6 +1,7 @@
 local M = {}
 
 local constants = require("toggleterm.constants")
+local utils = require("toggleterm.utils")
 
 local fn = vim.fn
 local fmt = string.format
@@ -184,16 +185,14 @@ local split_commands = {
 }
 
 --- @param size number/function
-local function resolve_size(size)
+function M._resolve_size(size,term)
   if type(size) == 'number' then
-    return function()
-      return size
-    end
-  end
-  if type(size) == 'function' then
     return size
   end
-  error(string.format('The input %s is not of type "number" or "function".',size))
+  if term and type(size) == 'function' then
+    return size(term)
+  end
+  utils.echomsg(string.format('The input %s is not of type "number" or "function".',size),"Error")
 end
 
 --- @param size number
@@ -202,8 +201,7 @@ function M.open_split(size, term)
   local has_open, win_ids = M.find_open_windows()
   local commands = split_commands[term.direction]
 
-  size = M.get_size(size)
-  size = resolve_size(size)(term)
+  size = M._resolve_size(M.get_size(size), term)
   if has_open then
     -- we need to be in the terminal window most recently opened
     -- in order to split to the right of it
@@ -254,8 +252,8 @@ function M.open_float(term)
   local opts = term.float_opts or {}
   local valid_buf = term.bufnr and api.nvim_buf_is_valid(term.bufnr)
   local buf = valid_buf and term.bufnr or api.nvim_create_buf(false, false)
-  local width = resolve_size(opts.width)(term) or math.ceil(math.min(vim.o.columns, math.max(80, vim.o.columns - 20)))
-  local height = resolve_size(opts.height)(term) or math.ceil(math.min(vim.o.lines, math.max(20, vim.o.lines - 10)))
+  local width = M._resolve_size(opts.width, term) or math.ceil(math.min(vim.o.columns, math.max(80, vim.o.columns - 20)))
+  local height = M._resolve_size(opts.height, term) or math.ceil(math.min(vim.o.lines, math.max(20, vim.o.lines - 10)))
 
   local border = opts.border == "curved" and curved or opts.border or "single"
   local win = api.nvim_open_win(buf, true, {

--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -186,10 +186,11 @@ local split_commands = {
 
 --- @param size number/function
 function M._resolve_size(size,term)
-  if type(size) == 'number' then
+  if size == nil then
+    return
+  elseif type(size) == 'number' then
     return size
-  end
-  if term and type(size) == 'function' then
+  elseif term and type(size) == 'function' then
     return size(term)
   end
   utils.echomsg(string.format('The input %s is not of type "number" or "function".',size),"Error")

--- a/tests/terminal_spec.lua
+++ b/tests/terminal_spec.lua
@@ -211,6 +211,25 @@ describe("ToggleTerm tests:", function()
       assert.equal("popup", fn.win_gettype(fn.win_id2win(wins[1])))
     end)
 
+    it("should not change numbers when resolving size",function()
+      local term = Terminal:new()
+      local size = 20
+      assert.equal(size, ui._resolve_size(size))
+      assert.equal(size, ui._resolve_size(size, term))
+    end)
+
+    it("should evaluate custom functions when resolving size",function()
+      local term = Terminal:new({ direction = "vertical" })
+      local size1 = 20
+      local size2 = function(term)
+        if term.direction == "vertical" then
+          return size1
+        end
+        return 0
+      end
+      assert.equal(ui._resolve_size(size2,term),size1)
+    end)
+
     -- FIXME the height is passed in correctly but is returned as 15
     -- which seems to be an nvim quirk not the code
     it("should open with user configuration if set", function()


### PR DESCRIPTION
Allows users to give a function that returns the size wanted.
The option to simply give a number is kept.

Works for size of split and for width and height of float.

---

For example a user can give use the following in their setup:
```
⋮
size = function(term)
  if term.direction == 'horizontal' then
    return math.floor(vim.o.lines * 0.2)
  elseif term.direction == 'vertical' then
    return math.floor(vim.o.columns * 0.3)
  end
end,
⋮
```
To have horizontally split terminals take up 20% of the height, and vertically split terminals take up 30% of the width.