### PR TITLE
Format cmd in OS compatible way

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,6 @@ Each terminal can take the following arguments:
 ```lua
 Terminal:new {
   cmd = string -- command to execute when creating the terminal e.g. 'top'
-  no_format = boolean -- disables formatting of command input 
   direction = string -- the layout for the terminal, same as the main config options
   dir = string -- the directory for the terminal
   on_open = fun(t: Terminal) -- function to run when the terminal opens

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ for showing terminal UIs like `lazygit`, `htop` etc.
 Each terminal can take the following arguments:
 ```lua
 Terminal:new {
-  cmd =  string -- command to execute when creating the terminal e.g. 'top'
+  cmd = string -- command to execute when creating the terminal e.g. 'top'
+  no_format = boolean -- disables formatting of command input 
   direction = string -- the layout for the terminal, same as the main config options
   dir = string -- the directory for the terminal
   on_open = fun(t: Terminal) -- function to run when the terminal opens

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -9,8 +9,8 @@ local api = vim.api
 local fmt = string.format
 local fn = vim.fn
 
-local command_sep = has("win32") and "&" or ";"
-local comment_sep = has("win32") and "::" or "#"
+local command_sep = vim.fn.has("win32") and "&" or ";"
+local comment_sep = vim.fn.has("win32") and "::" or "#"
 
 ---@type Terminal[]
 local terminals = {}

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -9,8 +9,8 @@ local api = vim.api
 local fmt = string.format
 local fn = vim.fn
 
-local command_sep = vim.fn.has("win32") and "&" or ";"
-local comment_sep = vim.fn.has("win32") and "::" or "#"
+local command_sep = (vim.fn.has("win32") == 1) and "&" or ";"
+local comment_sep = (vim.fn.has("win32") == 1) and "::" or "#"
 
 ---@type Terminal[]
 local terminals = {}

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -14,6 +14,7 @@ local terminals = {}
 
 --- @class Terminal
 --- @field cmd string
+--- @field no_format boolean disables formatting of command input
 --- @field direction string the layout style for the terminal
 --- @field id number
 --- @field bufnr number
@@ -220,7 +221,7 @@ end
 ---@private
 function Terminal:__spawn()
   local cmd = self.cmd or config.get("shell")
-  cmd = fmt("%s;#%s#%d", cmd, term_ft, self.id)
+  cmd = self.no_format and cmd or fmt("%s;#%s#%d", cmd, term_ft, self.id)
   self.job_id = fn.termopen(cmd, {
     detach = 1,
     cwd = _get_dir(self.dir),


### PR DESCRIPTION
Currently when opening a new terminal and providing a command, this command is formatted using semicolons, ";".

- On Linux, this can be used as a separator between any list of commands (I think?).
- On Windows, some commands can be separated with semicolons, but others can't.
  Some commands will read the entire line, and not stop at semicolons (see [here](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/----command-separator-#remarks)).
(In my use case, the "vifm" command line file manager reads the full line.)

Therefore it would be good to add an option to disable this formatting.