### PR TITLE
fix: delete buffer on process exit

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -217,6 +217,9 @@ local function __handle_exit(term)
     end
     if config.get("close_on_exit") then
       term:close()
+      if api.nvim_buf_is_loaded(term.bufnr) then
+        api.nvim_buf_delete(term.bufnr, { force = true })
+      end
     end
   end
 end


### PR DESCRIPTION
This should fix #43 by deleting the buffer when the process exits