### PR TITLE
fix: set `signcolumn` to `no` by default

### DIFF
--- a/lua/toggleterm/ui.lua
+++ b/lua/toggleterm/ui.lua
@@ -45,6 +45,7 @@ function M.set_options(win, buf, term)
   end
   vim.bo[buf].buflisted = false
   vim.bo[buf].filetype = constants.term_ft
+  vim.wo[win].signcolumn = "no"
 
   local conf = require("toggleterm.config").get()
   if conf.hide_numbers then


### PR DESCRIPTION
The signcolumn may be useless for a terminal window, so set it to no by default.

## How to test

1. open neovim
2. `:set signcolumn=yes`
3. `:ToggleTerm`