### PR TITLE
fix(parse): correct quotes matching for TermExec commands

### DIFF
--- a/lua/toggleterm/commandline.lua
+++ b/lua/toggleterm/commandline.lua
@@ -21,6 +21,11 @@ function M.parse(args)
       -- 1. extract the quoted command
       local pattern = "(%S+)=" .. quotes
       for key, value in args:gmatch(pattern) do
+        -- Check if the current OS is Windows so we can determine if +shellslash
+        -- exists and if it exists, then determine if it is enabled. In that way,
+        -- we can determine if we should match the value with single or double quotes.
+        quotes = jit.os ~= "Windows" and p.single or vim.g.shellslash == "yes" and quotes or p.single
+
         value = fn.shellescape(value)
         result[vim.trim(key)] = fn.expandcmd(value:match(quotes))
       end


### PR DESCRIPTION
Hey, after a while without using my `TermExec` commands I decided to trigger them and found that they weren't working properly since the command was `null` instead of the passed value (e.g. `git status`) when double quotes are used for enclosing the command. This PR aims to fix this behavior by checking two things before matching the command with the quoting.

1. Checks if the current OS is Windows or not by using `jit.os`.
2. Checks if the `+shellslash` feature exists and if it is turned on.

But, why check those things? Well, they're needed for some reasons:

1. The Vimscript `shellescape` function works in a very peculiar way regarding the quoting.

**From the** `shellescape` function **docs:**
> On Windows when `'shellslash'` is not set, encloses {string} in double-quotes and doubles all double-quotes within {string}.
> Otherwise encloses {string} in single-quotes and replaces all `"'"` with `"'\''"`.

2. The `shellslash` feature is only for Windows, that means we also need to check its value in addition to point 1 if the current OS is Windows because of how `shellescape` manages the quoting.

So basically, what was happening is that if you have used double quotes for enclosing your command the `value:match(quotes)` statement will return nil because the `shellescape` function enclosed the command in single quotes.

I only have tested in Linux because I don't have access to a Windows machine, but should work as expected too. Let me know if something needs to be changed.