### PR TITLE
fix: remove id from the list of available ids on terminal exit

### DIFF
--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -59,8 +59,8 @@ end
 --- remove the passed id from the list of available ids
 ---@param num number
 local function decrement_id(num)
-  vim.tbl_filter(function(id)
-    return id == num
+  ids = vim.tbl_filter(function(id)
+    return id ~= num
   end, ids)
 end
 


### PR DESCRIPTION
Ran into a problem where each newly opened terminal would have an incremental id 
assigned to it, even after all previous ones have been closed. These changes fixed 
things for me, so I'm making a pr instead of raising an issue, as requested.