### PR TITLE
Use <Cmd> instead of <C-\><C-N>: in terminal mode mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ alternatively you can do this manually (not recommended but, your prerogative)
 let g:toggleterm_terminal_mapping = '<C-t>'
 " or manually...
 autocmd TermEnter term://*toggleterm#*
-      \ tnoremap <silent><c-t> <C-\><C-n>:exe v:count1 . "ToggleTerm"<CR>
+      \ tnoremap <silent><c-t> <Cmd>exe v:count1 . "ToggleTerm"<CR>
 
 " By applying the mappings this way you can pass a count to your
 " mapping to open a specific window.

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -78,7 +78,7 @@ local function setup_buffer_mappings(bufnr)
   local conf = config.get()
   local mapping = conf.open_mapping
   if mapping and conf.insert_mappings then
-    api.nvim_buf_set_keymap(bufnr, "t", mapping, [[<C-\><C-n>:execute v:count . "ToggleTerm"<CR>]], {
+    api.nvim_buf_set_keymap(bufnr, "t", mapping, [[<Cmd>execute v:count . "ToggleTerm"<CR>]], {
       silent = true,
       noremap = true,
     })


### PR DESCRIPTION
I didn't notice this in #53.
This change actually solves a bug: when mapping is `<C-t>` and it is mapped to `<C-\><C-n>:execute v:count . "ToggleTerm"<CR>`, pressing `<C-\><C-t>` types `<C-n>:execute v:count . "ToggleTerm"<CR>` in the terminal, and changing `<C-\><C-n>:` to `<Cmd>` solves this bug.