### PR TITLE
feat: add close_on_exit field to the Terminal class

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Terminal:new {
   cmd = string -- command to execute when creating the terminal e.g. 'top'
   direction = string -- the layout for the terminal, same as the main config options
   dir = string -- the directory for the terminal
+  close_on_exit = bool -- close the terminal window when the process exits
   on_open = fun(t: Terminal) -- function to run when the terminal opens
   on_close = fun(t: Terminal) -- function to run when the terminal closes
   -- callbacks for processing the output

--- a/lua/toggleterm/terminal.lua
+++ b/lua/toggleterm/terminal.lua
@@ -27,6 +27,7 @@ local terminals = {}
 --- @field name string the name of the terminal
 --- @field count number the count that triggers that specific terminal
 --- @field hidden boolean whether or not to include this terminal in the terminals list
+--- @field close_on_exit boolean whether or not to close the terminal window when the process exits
 --- @field float_opts table<string, any>
 --- @field on_stdout fun(job: number, exit_code: number, type: string)
 --- @field on_stderr fun(job: number, data: string[], name: string)
@@ -146,6 +147,9 @@ function Terminal:new(term)
   term.id = id or next_id()
   term.hidden = term.hidden or false
   term.float_opts = vim.tbl_deep_extend("keep", term.float_opts or {}, conf.float_opts)
+  if term.close_on_exit == nil then
+    term.close_on_exit = conf.close_on_exit
+  end
   -- Add the newly created terminal to the list of all terminals
   return setmetatable(term, self)
 end
@@ -243,7 +247,7 @@ local function __handle_exit(term)
     if term.on_exit then
       term:on_exit(...)
     end
-    if config.get("close_on_exit") then
+    if term.close_on_exit then
       term:close()
       if api.nvim_buf_is_loaded(term.bufnr) then
         api.nvim_buf_delete(term.bufnr, { force = true })


### PR DESCRIPTION
Add a `close_on_exit` field to the Terminal class.
If not specified it uses the global `close_on_exit` specified in the config.